### PR TITLE
feat: admin impersonation token endpoint

### DIFF
--- a/app/admin/tasks.py
+++ b/app/admin/tasks.py
@@ -1,0 +1,79 @@
+from datetime import datetime, timezone
+
+from fastapi import HTTPException
+from firebase_admin import auth as firebase_auth
+from starlette import status
+
+from app.firebase_setup import db
+from app.utils import app_logger
+
+# Impersonation is VIEW-ONLY by product constraint: an admin must never be able to
+# trigger a charge as the user. The claims below propagate into the impersonated
+# session's ID token so Security Rules and payment endpoints can enforce this
+# authoritatively (see design doc docs/design/admin-impersonation.md, Layer 2/3).
+VIEW_ONLY = True
+# Firebase custom tokens are valid for 1 hour; surfaced to the client for UX.
+TOKEN_TTL_SECONDS = 3600
+
+
+def _is_admin(user_data: dict) -> bool:
+    return bool(user_data and user_data.get('isAdmin'))
+
+
+def mint_impersonation_token(admin_uid: str, target_uid: str) -> dict:
+    """Mint a Firebase custom token for `target_uid` on behalf of an admin.
+
+    The caller has already been verified as an admin by the route dependency.
+    """
+    if not target_uid:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='target_uid is required')
+
+    if target_uid == admin_uid:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Cannot impersonate yourself')
+
+    target_doc = db.collection('users').document(target_uid).get()
+    if not target_doc.exists:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Target user not found')
+
+    target_data = target_doc.to_dict() or {}
+
+    # Never let an admin impersonate another admin (privilege containment).
+    if _is_admin(target_data):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='Cannot impersonate another admin')
+
+    developer_claims = {
+        'impersonated': True,
+        'imp_admin_uid': admin_uid,
+        'imp_view_only': VIEW_ONLY,
+    }
+
+    custom_token = firebase_auth.create_custom_token(target_uid, developer_claims)
+    if isinstance(custom_token, bytes):
+        custom_token = custom_token.decode('utf-8')
+
+    _write_audit(admin_uid, target_uid)
+
+    app_logger.info('Admin %s minted impersonation token for user %s (view_only=%s)', admin_uid, target_uid, VIEW_ONLY)
+
+    return {
+        'custom_token': custom_token,
+        'target_uid': target_uid,
+        'view_only': VIEW_ONLY,
+        'expires_in': TOKEN_TTL_SECONDS,
+    }
+
+
+def _write_audit(admin_uid: str, target_uid: str) -> None:
+    """Best-effort audit record. A failure here must not block the admin, but is
+    logged loudly so it can be alerted on."""
+    record = {
+        'admin_uid': admin_uid,
+        'target_uid': target_uid,
+        'view_only': VIEW_ONLY,
+        'action': 'start',
+        'created_at': datetime.now(timezone.utc),
+    }
+    try:
+        db.collection('impersonation_audit').add(record)
+    except Exception:  # noqa: BLE001 - audit must never break the request
+        app_logger.exception('Failed to write impersonation audit record for admin %s -> %s', admin_uid, target_uid)

--- a/app/admin/tasks.py
+++ b/app/admin/tasks.py
@@ -20,36 +20,44 @@ def _is_admin(user_data: dict) -> bool:
     return bool(user_data and user_data.get('isAdmin'))
 
 
-def mint_impersonation_token(admin_uid: str, target_uid: str) -> dict:
-    """Mint a Firebase custom token for `target_uid` on behalf of an admin.
+def _mint(uid: str, claims: dict | None = None) -> str:
+    token = firebase_auth.create_custom_token(uid, claims) if claims else firebase_auth.create_custom_token(uid)
+    if isinstance(token, bytes):
+        token = token.decode('utf-8')
+    return token
 
-    The caller has already been verified as an admin by the route dependency.
+
+def mint_impersonation_token(admin_uid: str, target_uid: str) -> dict:
+    """Mint a view-only Firebase custom token for `target_uid`, plus a restore
+    token so the admin can return to their own session on exit.
+
+    `admin_uid` is asserted by the trusted Cloud Function; we still re-verify it
+    is genuinely an admin here as defense-in-depth.
     """
+    if not admin_uid:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='admin_uid is required')
     if not target_uid:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='target_uid is required')
-
     if target_uid == admin_uid:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Cannot impersonate yourself')
+
+    admin_doc = db.collection('users').document(admin_uid).get()
+    if not admin_doc.exists or not _is_admin(admin_doc.to_dict() or {}):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='Caller is not an admin')
 
     target_doc = db.collection('users').document(target_uid).get()
     if not target_doc.exists:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Target user not found')
 
-    target_data = target_doc.to_dict() or {}
-
     # Never let an admin impersonate another admin (privilege containment).
-    if _is_admin(target_data):
+    if _is_admin(target_doc.to_dict() or {}):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='Cannot impersonate another admin')
 
-    developer_claims = {
-        'impersonated': True,
-        'imp_admin_uid': admin_uid,
-        'imp_view_only': VIEW_ONLY,
-    }
-
-    custom_token = firebase_auth.create_custom_token(target_uid, developer_claims)
-    if isinstance(custom_token, bytes):
-        custom_token = custom_token.decode('utf-8')
+    # View-only session for the target; claims propagate into its ID token so
+    # rules / payment endpoints can enforce view-only authoritatively.
+    custom_token = _mint(target_uid, {'impersonated': True, 'imp_admin_uid': admin_uid, 'imp_view_only': VIEW_ONLY})
+    # Clean admin session (no impersonation claims) used to exit without re-login.
+    admin_restore_token = _mint(admin_uid)
 
     _write_audit(admin_uid, target_uid)
 
@@ -57,7 +65,9 @@ def mint_impersonation_token(admin_uid: str, target_uid: str) -> dict:
 
     return {
         'custom_token': custom_token,
+        'admin_restore_token': admin_restore_token,
         'target_uid': target_uid,
+        'admin_uid': admin_uid,
         'view_only': VIEW_ONLY,
         'expires_in': TOKEN_TTL_SECONDS,
     }

--- a/app/admin/views.py
+++ b/app/admin/views.py
@@ -1,61 +1,25 @@
-import typing as t
-
-from fastapi import APIRouter, Depends, HTTPException
-from fastapi.security.http import HTTPAuthorizationCredentials, HTTPBearer
-from firebase_admin import auth as firebase_auth
-from starlette import status
+from fastapi import APIRouter, Depends
 
 from app.admin.tasks import mint_impersonation_token
-from app.firebase_setup import db
+from app.auth.views import get_token
 from app.models import ImpersonationTokenRequest, ImpersonationTokenResponse
 from app.utils import app_logger
 
 admin_router = APIRouter()
 
-# Unlike the rest of Plutus (which authenticates the *app* with a static
-# master_token), admin endpoints must authenticate a *user* and confirm they are
-# an admin. We therefore verify the caller's Firebase ID token directly.
-get_bearer_token = HTTPBearer(auto_error=False)
-
-
-def get_admin_uid(
-    auth: t.Optional[HTTPAuthorizationCredentials] = Depends(get_bearer_token),
-) -> str:
-    """Verify the bearer is a valid Firebase ID token for an admin user.
-
-    Returns the admin's uid. Raises 401 for missing/invalid tokens and 403 when
-    the authenticated user is not an admin.
-    """
-    if auth is None:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail='Missing authorization')
-
-    try:
-        decoded = firebase_auth.verify_id_token(auth.credentials)
-    except Exception:  # noqa: BLE001 - any verification failure is a 401
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail='Invalid or expired ID token')
-
-    uid = decoded.get('uid')
-    if not uid:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail='Token missing uid')
-
-    # Authoritative gate. Prefer a tamper-proof custom claim (`admin: true`); fall
-    # back to the users/<uid>.isAdmin Firestore flag so this works before claims
-    # are backfilled. The Firestore flag MUST be write-locked to the Admin SDK.
-    if decoded.get('admin') is True:
-        return uid
-
-    user_doc = db.collection('users').document(uid).get()
-    if not user_doc.exists or not (user_doc.to_dict() or {}).get('isAdmin'):
-        app_logger.warning('Non-admin user %s attempted to use an admin endpoint', uid)
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='Caller is not an admin')
-
-    return uid
-
 
 @admin_router.post('/admin/impersonation_token', response_model=ImpersonationTokenResponse)
 def impersonation_token(
     data: ImpersonationTokenRequest,
-    admin_uid: str = Depends(get_admin_uid),
+    token: str = Depends(get_token),
 ):
-    app_logger.info('Admin %s requested an impersonation token for %s', admin_uid, data.target_uid)
-    return mint_impersonation_token(admin_uid, data.target_uid)
+    """Mint a view-only impersonation token for an admin.
+
+    Transport model (Option A): this endpoint is only reachable by the trusted
+    Cloud Function proxy, which authenticates with the static ``master_token``
+    (``get_token``) and asserts the caller's Firebase-verified ``admin_uid`` in
+    the body. Plutus re-checks that ``admin_uid`` is genuinely an admin as
+    defense-in-depth before minting (see ``mint_impersonation_token``).
+    """
+    app_logger.info('Impersonation token requested: admin %s -> target %s', data.admin_uid, data.target_uid)
+    return mint_impersonation_token(data.admin_uid, data.target_uid)

--- a/app/admin/views.py
+++ b/app/admin/views.py
@@ -1,0 +1,61 @@
+import typing as t
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.security.http import HTTPAuthorizationCredentials, HTTPBearer
+from firebase_admin import auth as firebase_auth
+from starlette import status
+
+from app.admin.tasks import mint_impersonation_token
+from app.firebase_setup import db
+from app.models import ImpersonationTokenRequest, ImpersonationTokenResponse
+from app.utils import app_logger
+
+admin_router = APIRouter()
+
+# Unlike the rest of Plutus (which authenticates the *app* with a static
+# master_token), admin endpoints must authenticate a *user* and confirm they are
+# an admin. We therefore verify the caller's Firebase ID token directly.
+get_bearer_token = HTTPBearer(auto_error=False)
+
+
+def get_admin_uid(
+    auth: t.Optional[HTTPAuthorizationCredentials] = Depends(get_bearer_token),
+) -> str:
+    """Verify the bearer is a valid Firebase ID token for an admin user.
+
+    Returns the admin's uid. Raises 401 for missing/invalid tokens and 403 when
+    the authenticated user is not an admin.
+    """
+    if auth is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail='Missing authorization')
+
+    try:
+        decoded = firebase_auth.verify_id_token(auth.credentials)
+    except Exception:  # noqa: BLE001 - any verification failure is a 401
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail='Invalid or expired ID token')
+
+    uid = decoded.get('uid')
+    if not uid:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail='Token missing uid')
+
+    # Authoritative gate. Prefer a tamper-proof custom claim (`admin: true`); fall
+    # back to the users/<uid>.isAdmin Firestore flag so this works before claims
+    # are backfilled. The Firestore flag MUST be write-locked to the Admin SDK.
+    if decoded.get('admin') is True:
+        return uid
+
+    user_doc = db.collection('users').document(uid).get()
+    if not user_doc.exists or not (user_doc.to_dict() or {}).get('isAdmin'):
+        app_logger.warning('Non-admin user %s attempted to use an admin endpoint', uid)
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='Caller is not an admin')
+
+    return uid
+
+
+@admin_router.post('/admin/impersonation_token', response_model=ImpersonationTokenResponse)
+def impersonation_token(
+    data: ImpersonationTokenRequest,
+    admin_uid: str = Depends(get_admin_uid),
+):
+    app_logger.info('Admin %s requested an impersonation token for %s', admin_uid, data.target_uid)
+    return mint_impersonation_token(admin_uid, data.target_uid)

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from fastapi import FastAPI
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 
+from app.admin.views import admin_router
 from app.auth.views import auth_router
 from app.auto.cal_tasks import auto_check_and_renew_channels
 from app.auto.payout_task import process_platform_payout
@@ -54,6 +55,7 @@ if bool(settings.logfire_token) and settings.testing is False and settings.dev_m
 logging.config.dictConfig(config)
 
 app.include_router(auth_router)
+app.include_router(admin_router)
 app.include_router(cal_router)
 app.include_router(cal_webhook_router)
 app.include_router(stripe_router)

--- a/app/models.py
+++ b/app/models.py
@@ -37,13 +37,16 @@ class OffSessionPayment(BaseModel):
 
 class ImpersonationTokenRequest(BaseModel):
     target_uid: str  # Firebase uid of the user the admin wants to view as
+    admin_uid: str  # caller's uid, asserted by the trusted Cloud Function (master_token holder)
 
 
 class ImpersonationTokenResponse(BaseModel):
-    custom_token: str  # Firebase custom token for signInWithCustomToken
+    custom_token: str  # Firebase custom token to sign in AS the target (view-only)
+    admin_restore_token: str  # Firebase custom token to sign back in as the admin on exit
     target_uid: str
+    admin_uid: str
     view_only: bool
-    expires_in: int  # seconds the Firebase custom token is valid for
+    expires_in: int  # seconds the Firebase custom tokens are valid for
 
 
 class PropertyCal(BaseModel):

--- a/app/models.py
+++ b/app/models.py
@@ -35,6 +35,17 @@ class OffSessionPayment(BaseModel):
     guest_email: str
 
 
+class ImpersonationTokenRequest(BaseModel):
+    target_uid: str  # Firebase uid of the user the admin wants to view as
+
+
+class ImpersonationTokenResponse(BaseModel):
+    custom_token: str  # Firebase custom token for signInWithCustomToken
+    target_uid: str
+    view_only: bool
+    expires_in: int  # seconds the Firebase custom token is valid for
+
+
 class PropertyCal(BaseModel):
     property_ref: str
     cal_id: str

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -21,8 +21,8 @@ client = TestClient(app)
 ADMIN_UID = 'admin_uid'
 TARGET_UID = 'target_uid'
 OTHER_ADMIN_UID = 'other_admin_uid'
+NON_ADMIN_UID = 'non_admin_uid'
 
-VERIFY = 'app.admin.views.firebase_auth.verify_id_token'
 CREATE = 'app.admin.tasks.firebase_auth.create_custom_token'
 
 
@@ -31,68 +31,68 @@ class TestImpersonationToken(TestCase):
         self.db = MOCK_DB
         self.db.collection('users').document(ADMIN_UID).set({'isAdmin': True})
         self.db.collection('users').document(OTHER_ADMIN_UID).set({'isAdmin': True})
+        self.db.collection('users').document(NON_ADMIN_UID).set({'isAdmin': False})
         self.db.collection('users').document(TARGET_UID).set({'isAdmin': False, 'display_name': 'Debra'})
-        self.headers = {'Authorization': 'Bearer fake-id-token'}
+        # Option A: the trusted Cloud Function authenticates with the master/test token.
+        self.headers = {'Authorization': f'Bearer {settings.test_token}'}
 
-    def _post(self, target_uid):
-        return client.post('/admin/impersonation_token', headers=self.headers, json={'target_uid': target_uid})
+    def _post(self, admin_uid, target_uid, headers=None):
+        return client.post(
+            '/admin/impersonation_token',
+            headers=self.headers if headers is None else headers,
+            json={'admin_uid': admin_uid, 'target_uid': target_uid},
+        )
 
-    @patch(CREATE, return_value=b'fake-custom-token')
-    @patch(VERIFY, return_value={'uid': ADMIN_UID})
-    def test_admin_can_mint_token(self, _verify, _create):
-        r = self._post(TARGET_UID)
+    @patch(CREATE, return_value=b'tok')
+    def test_admin_can_mint_tokens(self, _create):
+        r = self._post(ADMIN_UID, TARGET_UID)
         self.assertEqual(r.status_code, 200, r.text)
         body = r.json()
-        self.assertEqual(body['custom_token'], 'fake-custom-token')
+        self.assertEqual(body['custom_token'], 'tok')
+        self.assertEqual(body['admin_restore_token'], 'tok')
         self.assertEqual(body['target_uid'], TARGET_UID)
+        self.assertEqual(body['admin_uid'], ADMIN_UID)
         self.assertTrue(body['view_only'])
-        # claims must mark the session as impersonated + view-only
-        _create.assert_called_once()
-        args, _ = _create.call_args
-        self.assertEqual(args[0], TARGET_UID)
-        self.assertEqual(args[1], {'impersonated': True, 'imp_admin_uid': ADMIN_UID, 'imp_view_only': True})
+        # Two tokens minted: target (view-only claims) + admin restore (clean).
+        self.assertEqual(_create.call_count, 2)
+        target_call = next(c for c in _create.call_args_list if c.args[0] == TARGET_UID)
+        self.assertEqual(target_call.args[1], {'impersonated': True, 'imp_admin_uid': ADMIN_UID, 'imp_view_only': True})
+        restore_call = next(c for c in _create.call_args_list if c.args[0] == ADMIN_UID)
+        # restore token carries no impersonation claims
+        self.assertEqual(len(restore_call.args), 1)
 
-    @patch(CREATE, return_value=b'fake-custom-token')
-    @patch(VERIFY, return_value={'uid': TARGET_UID})
-    def test_non_admin_forbidden(self, _verify, _create):
-        r = self._post(ADMIN_UID)
+    @patch(CREATE, return_value=b'tok')
+    def test_asserted_admin_must_actually_be_admin(self, _create):
+        r = self._post(NON_ADMIN_UID, TARGET_UID)
         self.assertEqual(r.status_code, 403, r.text)
         _create.assert_not_called()
 
-    @patch(CREATE, return_value=b'fake-custom-token')
-    @patch(VERIFY, return_value={'uid': ADMIN_UID})
-    def test_cannot_impersonate_admin(self, _verify, _create):
-        r = self._post(OTHER_ADMIN_UID)
+    @patch(CREATE, return_value=b'tok')
+    def test_cannot_impersonate_admin(self, _create):
+        r = self._post(ADMIN_UID, OTHER_ADMIN_UID)
         self.assertEqual(r.status_code, 403, r.text)
         _create.assert_not_called()
 
-    @patch(CREATE, return_value=b'fake-custom-token')
-    @patch(VERIFY, return_value={'uid': ADMIN_UID})
-    def test_cannot_impersonate_self(self, _verify, _create):
-        r = self._post(ADMIN_UID)
+    @patch(CREATE, return_value=b'tok')
+    def test_cannot_impersonate_self(self, _create):
+        r = self._post(ADMIN_UID, ADMIN_UID)
         self.assertEqual(r.status_code, 400, r.text)
         _create.assert_not_called()
 
-    @patch(CREATE, return_value=b'fake-custom-token')
-    @patch(VERIFY, return_value={'uid': ADMIN_UID})
-    def test_target_not_found(self, _verify, _create):
-        r = self._post('does_not_exist')
+    @patch(CREATE, return_value=b'tok')
+    def test_target_not_found(self, _create):
+        r = self._post(ADMIN_UID, 'does_not_exist')
         self.assertEqual(r.status_code, 404, r.text)
         _create.assert_not_called()
 
-    @patch(VERIFY, side_effect=ValueError('bad token'))
-    def test_invalid_token_unauthorized(self, _verify):
-        r = self._post(TARGET_UID)
+    @patch(CREATE, return_value=b'tok')
+    def test_missing_master_token_unauthorized(self, _create):
+        r = self._post(ADMIN_UID, TARGET_UID, headers={})
         self.assertEqual(r.status_code, 401, r.text)
+        _create.assert_not_called()
 
-    def test_missing_token_unauthorized(self):
-        r = client.post('/admin/impersonation_token', json={'target_uid': TARGET_UID})
+    @patch(CREATE, return_value=b'tok')
+    def test_wrong_master_token_unauthorized(self, _create):
+        r = self._post(ADMIN_UID, TARGET_UID, headers={'Authorization': 'Bearer nope'})
         self.assertEqual(r.status_code, 401, r.text)
-
-    @patch(CREATE, return_value=b'fake-custom-token')
-    @patch(VERIFY, return_value={'uid': ADMIN_UID, 'admin': True})
-    def test_custom_claim_admin_allowed(self, _verify, _create):
-        # An admin identified purely via custom claim (no Firestore isAdmin) is allowed.
-        self.db.collection('users').document('claim_only_admin').set({'isAdmin': False})
-        r = self._post(TARGET_UID)
-        self.assertEqual(r.status_code, 200, r.text)
+        _create.assert_not_called()

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,98 @@
+import os
+
+# Must be set before app.settings / app.firebase_setup load so `db` binds to the
+# in-memory MockFirestore rather than a real Firestore client.
+os.environ['TESTING'] = 'true'
+
+from unittest import TestCase  # noqa: E402
+from unittest.mock import patch  # noqa: E402
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from app.utils import settings  # noqa: E402
+
+settings.testing = True
+
+from app.firebase_setup import MOCK_DB  # noqa: E402
+from app.main import app  # noqa: E402
+
+client = TestClient(app)
+
+ADMIN_UID = 'admin_uid'
+TARGET_UID = 'target_uid'
+OTHER_ADMIN_UID = 'other_admin_uid'
+
+VERIFY = 'app.admin.views.firebase_auth.verify_id_token'
+CREATE = 'app.admin.tasks.firebase_auth.create_custom_token'
+
+
+class TestImpersonationToken(TestCase):
+    def setUp(self):
+        self.db = MOCK_DB
+        self.db.collection('users').document(ADMIN_UID).set({'isAdmin': True})
+        self.db.collection('users').document(OTHER_ADMIN_UID).set({'isAdmin': True})
+        self.db.collection('users').document(TARGET_UID).set({'isAdmin': False, 'display_name': 'Debra'})
+        self.headers = {'Authorization': 'Bearer fake-id-token'}
+
+    def _post(self, target_uid):
+        return client.post('/admin/impersonation_token', headers=self.headers, json={'target_uid': target_uid})
+
+    @patch(CREATE, return_value=b'fake-custom-token')
+    @patch(VERIFY, return_value={'uid': ADMIN_UID})
+    def test_admin_can_mint_token(self, _verify, _create):
+        r = self._post(TARGET_UID)
+        self.assertEqual(r.status_code, 200, r.text)
+        body = r.json()
+        self.assertEqual(body['custom_token'], 'fake-custom-token')
+        self.assertEqual(body['target_uid'], TARGET_UID)
+        self.assertTrue(body['view_only'])
+        # claims must mark the session as impersonated + view-only
+        _create.assert_called_once()
+        args, _ = _create.call_args
+        self.assertEqual(args[0], TARGET_UID)
+        self.assertEqual(args[1], {'impersonated': True, 'imp_admin_uid': ADMIN_UID, 'imp_view_only': True})
+
+    @patch(CREATE, return_value=b'fake-custom-token')
+    @patch(VERIFY, return_value={'uid': TARGET_UID})
+    def test_non_admin_forbidden(self, _verify, _create):
+        r = self._post(ADMIN_UID)
+        self.assertEqual(r.status_code, 403, r.text)
+        _create.assert_not_called()
+
+    @patch(CREATE, return_value=b'fake-custom-token')
+    @patch(VERIFY, return_value={'uid': ADMIN_UID})
+    def test_cannot_impersonate_admin(self, _verify, _create):
+        r = self._post(OTHER_ADMIN_UID)
+        self.assertEqual(r.status_code, 403, r.text)
+        _create.assert_not_called()
+
+    @patch(CREATE, return_value=b'fake-custom-token')
+    @patch(VERIFY, return_value={'uid': ADMIN_UID})
+    def test_cannot_impersonate_self(self, _verify, _create):
+        r = self._post(ADMIN_UID)
+        self.assertEqual(r.status_code, 400, r.text)
+        _create.assert_not_called()
+
+    @patch(CREATE, return_value=b'fake-custom-token')
+    @patch(VERIFY, return_value={'uid': ADMIN_UID})
+    def test_target_not_found(self, _verify, _create):
+        r = self._post('does_not_exist')
+        self.assertEqual(r.status_code, 404, r.text)
+        _create.assert_not_called()
+
+    @patch(VERIFY, side_effect=ValueError('bad token'))
+    def test_invalid_token_unauthorized(self, _verify):
+        r = self._post(TARGET_UID)
+        self.assertEqual(r.status_code, 401, r.text)
+
+    def test_missing_token_unauthorized(self):
+        r = client.post('/admin/impersonation_token', json={'target_uid': TARGET_UID})
+        self.assertEqual(r.status_code, 401, r.text)
+
+    @patch(CREATE, return_value=b'fake-custom-token')
+    @patch(VERIFY, return_value={'uid': ADMIN_UID, 'admin': True})
+    def test_custom_claim_admin_allowed(self, _verify, _create):
+        # An admin identified purely via custom claim (no Firestore isAdmin) is allowed.
+        self.db.collection('users').document('claim_only_admin').set({'isAdmin': False})
+        r = self._post(TARGET_UID)
+        self.assertEqual(r.status_code, 200, r.text)


### PR DESCRIPTION
## What
Backend half of the admin "view as another user" feature. Adds a single endpoint that mints a Firebase **custom token** for a target user after verifying the caller is an admin, so the Flutter client can `signInWithCustomToken` and render the app as that user. Implements the Plutus side of the design in teamworks PR #356.

## Endpoint
`POST /admin/impersonation_token`
- **Auth:** `Authorization: Bearer <admin Firebase ID token>` — verified via `firebase_admin.auth.verify_id_token`. This is a per-*user* gate, unlike the rest of Plutus which uses the static `master_token` (app-level).
- **Admin gate:** allows the caller if their verified token has custom claim `admin=true` **or** `users/<uid>.isAdmin == true` in Firestore (works today; migrate to claims later).
- **Body:** `{ "target_uid": "<uid>" }`
- **Response:** `{ custom_token, target_uid, view_only, expires_in }`
- **Claims embedded** in the minted token: `{ impersonated: true, imp_admin_uid, imp_view_only: true }` — these propagate into the impersonated session's ID token so Security Rules and (future) payment-endpoint checks can enforce view-only authoritatively.

## Guard rails / safety
- View-only by design (`imp_view_only: true`) — supports the product constraint that an admin must never trigger a charge as the user.
- Refuses to impersonate **yourself** (400) or **another admin** (403).
- Errors: `401` missing/invalid ID token, `403` non-admin / admin target, `404` unknown target.
- Best-effort audit row written to `impersonation_audit` (admin_uid, target_uid, view_only, action, created_at).

## Tests
`tests/test_admin.py` — 8 cases (admin success + claim shape, non-admin 403, admin-target 403, self 400, missing target 404, invalid token 401, missing token 401, custom-claim admin). Full suite: **26 passed**. `ruff check`/`format` clean.

## Files
- `app/admin/views.py` — router + `get_admin_uid` dependency
- `app/admin/tasks.py` — `mint_impersonation_token` + audit
- `app/models.py` — request/response models
- `app/main.py` — register `admin_router`
- `tests/test_admin.py`

## Open decisions / follow-ups (NOT in this PR)
1. **Admin identity:** ship with Firestore `isAdmin` now vs. backfill Firebase custom claims (`admin=true`). Both are supported; claims are tamper-proof. If keeping `isAdmin`, Security Rules must write-lock `users.isAdmin` to the Admin SDK.
2. **Layer-2 payment guard (recommended next):** add ID-token verification to `/off_session_payment`, `/extra_charge`, `/refund`, `/cancel_refund` and reject tokens carrying `impersonated`/`imp_view_only`. Today these use only `master_token` + an `actor_ref` string, so the client UI disable is currently the only block — the authoritative server-side block is this follow-up.
3. **Transport:** the Flutter app reaches Plutus via the `ffPrivateApiCall` Cloud Function proxy; it must **forward the admin's Firebase ID token** to this endpoint (or call Plutus directly). Confirm the proxy doesn't strip/replace `Authorization`.
4. **Firestore Security Rules:** deny client writes to `impersonation_audit`; optionally deny writes when `request.auth.token.imp_view_only == true`.

Pairs with: teamworks #356 (design), and the in-progress Flutter UI PR.
