### PR TITLE
fix: stop calendar sync promoting unpaid inquiries to bookings

### DIFF
--- a/app/cal/tasks.py
+++ b/app/cal/tasks.py
@@ -20,6 +20,40 @@ creds = service_account.Credentials.from_service_account_info(
     settings.firebase_credentials, scopes=['https://www.googleapis.com/auth/calendar']
 )
 
+# Fields the Google Calendar is authoritative for on a trip that already exists in
+# Firestore. Booking state (isInquiry, isOffer, upcoming, payment) is owned by the app.
+CALENDAR_OWNED_FIELDS = ('tripBeginDateTime', 'tripEndDateTime', 'tripDate', 'eventId', 'eventSummary')
+
+
+def is_eligible_for_event_backfill(trip_data: dict) -> bool:
+    """Whether the automatic sweep may create a calendar event for this trip.
+
+    Only trips that actually hold the room qualify. Inquiries and offers are still
+    awaiting host acceptance or guest payment; giving them an event puts an unpaid
+    slot on the property's calendar, and the resulting sync used to feed it back in
+    as a confirmed booking. Events for accepted offers are created deliberately by
+    the app via create_or_update_event_from_trip, not by this sweep.
+    """
+    if trip_data.get('cancelTrip'):
+        return False
+    if trip_data.get('isBlocked'):
+        # Host-blocked time holds the room without being a booking.
+        return True
+    return trip_data.get('isInquiry') is False and trip_data.get('isOffer') is False
+
+
+def calendar_event_id_for_trip(trip_id: str) -> str:
+    """Deterministic Google Calendar event ID for a trip.
+
+    Deriving the ID from the trip makes events().insert idempotent: two concurrent
+    syncs collide on the same ID (409) instead of creating two events for one booking,
+    which previously also produced a phantom duplicate trip on the next sync.
+
+    Google requires base32hex, so the trip ID is hex-encoded ('trip' and hex digits
+    are all within the permitted a-v0-9 range).
+    """
+    return 'trip' + trip_id.encode('utf-8').hex()
+
 
 def renew_notification_channel(calendar_id, channel_id, channel_type, channel_address):
     service = build('calendar', 'v3', credentials=creds)
@@ -235,9 +269,14 @@ def handle_validated_event(event: GCalEvent, property_doc_ref: Any):
 
 def update_existing_trip(trip_ref, trip_data: TripData, event: GCalEvent):
     """
-    Update an existing trip in the Firestore database from the Google Calendar event,
+    Update an existing trip in the Firestore database from the Google Calendar event.
+
+    Only CALENDAR_OWNED_FIELDS are written. Writing the whole TripData used to clobber
+    isInquiry (and reset tripCreated to the worker's start time), which silently promoted
+    unpaid inquiries into confirmed bookings.
     """
-    trip_ref.reference.update(trip_data.dict())
+    updates = {field: getattr(trip_data, field) for field in CALENDAR_OWNED_FIELDS}
+    trip_ref.reference.update(updates)
     app_logger.info('Updated trip for event: %s, trip ref: %s', event.id, trip_ref.id)
 
 
@@ -345,14 +384,18 @@ def create_events_for_future_trips(property_doc_id: str):
         for trip in future_trips:
             trip_data = trip.to_dict()
             app_logger.info('Trip data: %s', trip)
-            if 'eventId' not in trip_data:
-                # Call create_or_update_event_from_trip to create the event
-                app_logger.info('Creating event for trip: %s', trip.reference)
-                document_ref_str = 'properties/' + property_doc_id
-                trip_ref_str = 'trips/' + trip.id
-                create_or_update_event_from_trip(document_ref_str, trip_ref_str)
-            else:
+            if 'eventId' in trip_data:
                 app_logger.info('Event already exists for trip: %s', trip.reference)
+                continue
+            if not is_eligible_for_event_backfill(trip_data):
+                # Inquiries, offers awaiting payment and cancelled trips do not hold the room.
+                app_logger.info('Trip is not eligible for a calendar event, skipping: %s', trip.reference)
+                continue
+            # Call create_or_update_event_from_trip to create the event
+            app_logger.info('Creating event for trip: %s', trip.reference)
+            document_ref_str = 'properties/' + property_doc_id
+            trip_ref_str = 'trips/' + trip.id
+            create_or_update_event_from_trip(document_ref_str, trip_ref_str)
 
 
 def create_or_update_event_from_trip(property_ref, trip_ref):
@@ -425,9 +468,21 @@ def create_or_update_event_from_trip(property_ref, trip_ref):
                             calendarId=calendar_id, eventId=trip_data['eventId'], body=main_event_data
                         ).execute()
                     else:
-                        event = service.events().insert(calendarId=calendar_id, body=main_event_data).execute()
-                        app_logger.info('Created main event: %s', event['id'])
-                        trip_doc.reference.update({'eventId': event['id']})
+                        # Derive the ID from the trip so a concurrent call collides here
+                        # rather than creating a second event for the same booking.
+                        event_id = calendar_event_id_for_trip(trip_document_id)
+                        main_event_data['id'] = event_id
+                        try:
+                            service.events().insert(calendarId=calendar_id, body=main_event_data).execute()
+                            app_logger.info('Created main event: %s', event_id)
+                        except HttpError as exc:
+                            if exc.resp.status != 409:
+                                raise
+                            app_logger.info('Event %s already exists, adopting it for trip: %s', event_id, trip_ref)
+                            service.events().update(
+                                calendarId=calendar_id, eventId=event_id, body=main_event_data
+                            ).execute()
+                        trip_doc.reference.update({'eventId': event_id})
 
                 else:
                     app_logger.error('User document does not exist for: %s', trip_data['userRef'])

--- a/tests/test_cal.py
+++ b/tests/test_cal.py
@@ -1,0 +1,253 @@
+import os
+
+# Must be set before app.settings / app.firebase_setup load so `db` binds to the
+# in-memory MockFirestore rather than a real Firestore client.
+os.environ['TESTING'] = 'true'
+
+from datetime import datetime, timezone  # noqa: E402
+from unittest import TestCase  # noqa: E402
+from unittest.mock import patch  # noqa: E402
+
+import httplib2  # noqa: E402
+from googleapiclient.errors import HttpError  # noqa: E402
+
+from app.utils import settings  # noqa: E402
+
+settings.testing = True
+
+from app.cal.tasks import (  # noqa: E402
+    calendar_event_id_for_trip,
+    create_or_update_event_from_trip,
+    is_eligible_for_event_backfill,
+    update_existing_trip,
+)
+from app.firebase_setup import MOCK_DB  # noqa: E402
+from app.models import TripData  # noqa: E402
+
+BEGIN = datetime(2026, 8, 18, 15, 0, tzinfo=timezone.utc)
+END = datetime(2026, 8, 19, 0, 0, tzinfo=timezone.utc)
+
+
+class _StubEvent:
+    """Stand-in for GCalEvent; update_existing_trip only reads `.id`."""
+
+    id = 'evt_stub'
+
+
+def _confirmed_booking(**overrides):
+    trip = {
+        'isExternal': False,
+        'isInquiry': False,
+        'isOffer': False,
+        'cancelTrip': False,
+        'isBlocked': False,
+    }
+    trip.update(overrides)
+    return trip
+
+
+class TestIsCalendarEligible(TestCase):
+    """A calendar event must only ever be created for a real, held booking.
+
+    Regression guard for trip lpIbpX4hMByLuj4cJNVr: an unpaid inquiry was given a
+    Google Calendar event, and the resulting sync then flipped isInquiry to False,
+    silently promoting it to a confirmed booking.
+    """
+
+    def test_confirmed_booking_is_eligible(self):
+        self.assertTrue(is_eligible_for_event_backfill(_confirmed_booking()))
+
+    def test_inquiry_is_not_eligible(self):
+        self.assertFalse(is_eligible_for_event_backfill(_confirmed_booking(isInquiry=True)))
+
+    def test_offer_awaiting_payment_is_not_eligible(self):
+        self.assertFalse(is_eligible_for_event_backfill(_confirmed_booking(isOffer=True)))
+
+    def test_cancelled_trip_is_not_eligible(self):
+        self.assertFalse(is_eligible_for_event_backfill(_confirmed_booking(cancelTrip=True)))
+
+    def test_host_blocked_time_is_eligible(self):
+        # Blocked time holds the calendar even though it is not a paid booking.
+        blocked = _confirmed_booking(isBlocked=True, isInquiry=True, isOffer=True)
+        self.assertTrue(is_eligible_for_event_backfill(blocked))
+
+    def test_missing_flags_default_to_not_eligible(self):
+        # A half-written trip doc must not be given a calendar event.
+        self.assertFalse(is_eligible_for_event_backfill({}))
+
+
+class TestCalendarEventIdForTrip(TestCase):
+    """Deterministic event IDs make insert idempotent, killing the duplicate-event race."""
+
+    def test_is_deterministic(self):
+        self.assertEqual(
+            calendar_event_id_for_trip('lpIbpX4hMByLuj4cJNVr'),
+            calendar_event_id_for_trip('lpIbpX4hMByLuj4cJNVr'),
+        )
+
+    def test_differs_between_trips(self):
+        self.assertNotEqual(
+            calendar_event_id_for_trip('lpIbpX4hMByLuj4cJNVr'),
+            calendar_event_id_for_trip('19q4kp60qvbjnged6g0k1beh2o'),
+        )
+
+    def test_uses_charset_google_calendar_accepts(self):
+        # Google requires base32hex: characters a-v and 0-9, length 5-1024.
+        event_id = calendar_event_id_for_trip('lpIbpX4hMByLuj4cJNVr')
+        self.assertRegex(event_id, r'^[a-v0-9]{5,1024}$')
+
+
+class TestUpdateExistingTrip(TestCase):
+    """Calendar sync owns times; it must never rewrite booking-state fields."""
+
+    def setUp(self):
+        self.db = MOCK_DB
+        self.trip_id = 'existing_trip'
+        self.db.collection('trips').document(self.trip_id).set(
+            {
+                'isInquiry': True,
+                'isOffer': True,
+                'upcoming': True,
+                'tripCreated': datetime(2026, 5, 20, 16, 31, tzinfo=timezone.utc),
+                'tripBeginDateTime': BEGIN,
+                'tripEndDateTime': END,
+                'eventId': 'evt_stub',
+                'eventSummary': 'Old summary',
+            }
+        )
+        self.trip_data = TripData(
+            tripCreated=datetime(2026, 5, 21, 3, 40, tzinfo=timezone.utc),
+            isExternal=False,
+            isInquiry=False,
+            propertyRef=None,
+            tripBeginDateTime=datetime(2026, 8, 18, 16, 0, tzinfo=timezone.utc),
+            tripDate=datetime(2026, 8, 18, 0, 0, tzinfo=timezone.utc),
+            tripEndDateTime=datetime(2026, 8, 19, 1, 0, tzinfo=timezone.utc),
+            eventId='evt_stub',
+            eventSummary='New summary',
+        )
+
+    def _run_and_reload(self):
+        snapshot = self.db.collection('trips').document(self.trip_id).get()
+        update_existing_trip(snapshot, self.trip_data, _StubEvent())
+        return self.db.collection('trips').document(self.trip_id).get().to_dict()
+
+    def test_does_not_overwrite_is_inquiry(self):
+        self.assertTrue(self._run_and_reload()['isInquiry'])
+
+    def test_does_not_overwrite_is_offer(self):
+        self.assertTrue(self._run_and_reload()['isOffer'])
+
+    def test_does_not_overwrite_trip_created(self):
+        self.assertEqual(
+            self._run_and_reload()['tripCreated'],
+            datetime(2026, 5, 20, 16, 31, tzinfo=timezone.utc),
+        )
+
+    def test_updates_times_from_the_calendar(self):
+        result = self._run_and_reload()
+        self.assertEqual(result['tripBeginDateTime'], datetime(2026, 8, 18, 16, 0, tzinfo=timezone.utc))
+        self.assertEqual(result['tripEndDateTime'], datetime(2026, 8, 19, 1, 0, tzinfo=timezone.utc))
+
+    def test_updates_event_summary(self):
+        self.assertEqual(self._run_and_reload()['eventSummary'], 'New summary')
+
+
+class _PathRef:
+    """MockFirestore refs have no `.path`; production code reads userRef.path."""
+
+    def __init__(self, path):
+        self.path = path
+
+
+class _Request:
+    def __init__(self, result, error=None):
+        self._result = result
+        self._error = error
+
+    def execute(self):
+        if self._error:
+            raise self._error
+        return self._result
+
+
+class _FakeEvents:
+    def __init__(self, insert_error=None):
+        self.inserted = []
+        self.updated = []
+        self._insert_error = insert_error
+
+    def insert(self, calendarId, body):
+        self.inserted.append(body)
+        # Google assigns a random ID when the caller does not supply one.
+        return _Request({'id': body.get('id', 'google_random_id')}, self._insert_error)
+
+    def update(self, calendarId, eventId, body):
+        self.updated.append(eventId)
+        return _Request({'id': eventId})
+
+
+class _FakeCalendarService:
+    def __init__(self, events):
+        self._events = events
+
+    def events(self):
+        return self._events
+
+
+def _conflict_error():
+    return HttpError(httplib2.Response({'status': 409}), b'The requested identifier already exists.')
+
+
+class TestCreateEventFromTrip(TestCase):
+    """Event IDs must be derived from the trip so concurrent syncs cannot duplicate.
+
+    Regression guard for trip lpIbpX4hMByLuj4cJNVr, which got two calendar events
+    369ms apart; the second had no matching trip and became a phantom trip doc.
+    """
+
+    TRIP_ID = 'lpIbpX4hMByLuj4cJNVr'
+    PROPERTY_ID = 'Us1f1bl7NC0TfAfQeITb'
+
+    def setUp(self):
+        self.db = MOCK_DB
+        self.db.collection('properties').document(self.PROPERTY_ID).set(
+            {'externalCalendar': 'cal@group.calendar.google.com', 'propertyName': 'Suite 14'}
+        )
+        self.db.collection('users').document('guest_uid').set({'display_name': 'Ada'})
+        self.db.collection('trips').document(self.TRIP_ID).set(
+            {
+                'userRef': _PathRef('users/guest_uid'),
+                'tripBeginDateTime': BEGIN,
+                'tripEndDateTime': END,
+                'isBlocked': False,
+            }
+        )
+
+    def _run(self, insert_error=None):
+        events = _FakeEvents(insert_error=insert_error)
+        with patch('app.cal.tasks.build', return_value=_FakeCalendarService(events)):
+            create_or_update_event_from_trip(f'properties/{self.PROPERTY_ID}', f'trips/{self.TRIP_ID}')
+        return events
+
+    def _stored_event_id(self):
+        return self.db.collection('trips').document(self.TRIP_ID).get().to_dict().get('eventId')
+
+    def test_insert_uses_deterministic_event_id(self):
+        events = self._run()
+        self.assertEqual(events.inserted[0]['id'], calendar_event_id_for_trip(self.TRIP_ID))
+
+    def test_writes_deterministic_event_id_back_to_the_trip(self):
+        self._run()
+        self.assertEqual(self._stored_event_id(), calendar_event_id_for_trip(self.TRIP_ID))
+
+    def test_duplicate_insert_adopts_existing_event_instead_of_creating_a_second(self):
+        # A concurrent sync already inserted this event; Google answers 409.
+        events = self._run(insert_error=_conflict_error())
+        self.assertEqual(events.updated, [calendar_event_id_for_trip(self.TRIP_ID)])
+        self.assertEqual(self._stored_event_id(), calendar_event_id_for_trip(self.TRIP_ID))
+
+    def test_non_conflict_http_errors_still_propagate(self):
+        server_error = HttpError(httplib2.Response({'status': 500}), b'backend error')
+        with self.assertRaises(HttpError):
+            self._run(insert_error=server_error)


### PR DESCRIPTION
## What happened

Trip `lpIbpX4hMByLuj4cJNVr` (Suite 14, Aug 18 2026, \$2348) was showing in the guest's **Bookings** tab as a confirmed upcoming booking with **no Stripe payment intent**, no transaction, and no addons. It was never paid for and the host never accepted it.

It was an inquiry that got laundered into a booking by the calendar sync. Three defects combined:

**1. The event-backfill sweep didn't care whether the trip was a booking.**
`create_events_for_future_trips` filtered only on `propertyRef`, `isExternal == False`, `tripBeginDateTime > now` and absence of `eventId`. It created a Google Calendar event for an unpaid inquiry nobody had accepted.

**2. The sync then wrote booking state back onto the trip.**
`update_existing_trip` did `trip_ref.reference.update(trip_data.dict())`, and `TripData` hardcodes `isInquiry=False`. That flipped the inquiry into a booking, which made it match the confirmed-bookings query (`upcoming == true && isInquiry == false && cancelTrip == false`). `upcoming` was already `true` — the app sets it at inquiry submission, and nothing in that query checks payment. It also reset `tripCreated` to the worker's process start time.

**3. Event IDs were assigned by Google and written back afterwards.**
Two concurrent calls both took the `insert` branch, producing two events for one trip 369ms apart (both descriptions read `Trip Ref: trips/lpIbpX4hMByLuj4cJNVr`). The second matched no trip on the next sync and became a phantom trip doc keyed by its event ID.

Timeline, all confirmed against production data and the Calendar API:

| when | what |
|---|---|
| 2026-05-20 16:31:34Z | guest submits inquiry; `upcoming: true` set here, unpaid |
| 2026-05-21 03:40:43Z | sweep creates **two** calendar events (service account) |
| 2026-05-21 03:40:49.42Z | sync creates phantom trip `19q4kp60qvbjnged6g0k1beh2o` |
| 2026-05-21 03:40:50.26Z | sync writes `isInquiry: False` onto the real trip |

## The fix

- **`is_eligible_for_event_backfill()`** — new predicate gating the sweep. Inquiries, offers awaiting payment and cancelled trips are skipped; host-blocked time still holds the room. Events for accepted offers are still created deliberately by the app via `create_or_update_event_from_trip`, so that flow is unchanged.
- **`CALENDAR_OWNED_FIELDS`** — `update_existing_trip` now writes only times, `tripDate`, `eventId` and `eventSummary`. Booking state (`isInquiry`, `isOffer`, `upcoming`, payment) stays owned by the app.
- **`calendar_event_id_for_trip()`** — event IDs derived from the trip ID (hex-encoded for Google's base32hex charset), making `insert` idempotent. A 409 adopts the existing event; other `HttpError`s still propagate.

## Tests

18 new tests in `tests/test_cal.py`, written before the fix. Two failed reproducing production exactly: `isInquiry` clobbered, and `tripCreated` overwritten with the worker-start-time fingerprint seen on the live docs. Full suite 43 passed.

## Production cleanup (already applied)

- `trips/lpIbpX4hMByLuj4cJNVr` restored to an inquiry (`isInquiry: true`, `eventId`/`eventSummary` removed)
- phantom `trips/19q4kp60qvbjnged6g0k1beh2o` deleted
- both calendar events deleted, freeing Aug 18 on Suite 14

Ordering mattered: `eventId` was cleared **before** deleting the events, because `handle_cancelled_event` stamps `cancelTrip: True` on any trip still holding that `eventId`. Verified post-webhook that `cancelTrip` is still `false`.

## Not covered here

The app still writes `upcoming: true` at inquiry submission, and the bookings query still checks only `upcoming && !isInquiry` with no payment check. That's the underlying sharp edge, but `upcoming` is load-bearing across many widgets so changing it is a separate refactor. These three fixes break the chain that exploited it.